### PR TITLE
feature/fix deep nested with default

### DIFF
--- a/src/rules/sort-destructure-keys-by-type.test.ts
+++ b/src/rules/sort-destructure-keys-by-type.test.ts
@@ -213,7 +213,6 @@ run({
       errors: [{ messageId: "sort" }],
     },
     {
-      only: true,
       description: "nested object destructuring with default values",
       code: `
 interface Level3 {

--- a/src/rules/sort-destructure-keys-by-type.test.ts
+++ b/src/rules/sort-destructure-keys-by-type.test.ts
@@ -213,25 +213,86 @@ run({
       errors: [{ messageId: "sort" }],
     },
     {
-      description: "nested object destructuring with default value for parent",
-      code: `type Nested = {
-  parent: { firstChild: string; secondChild: string };
-};
+        only: true,
+      description: "nested object destructuring with default values",
+      code: `
+      
+      interface Level5 {
+  a: string;
+  b: string;
+}
 
-export function Example(props: Nested) {
+interface Level4 {
+  level5: Level5;
+  a: string;
+  b: string;
+}
+
+interface Level3 {
+  level4: Level4;
+  a: string;
+  b: string;
+}
+
+interface Level2 {
+  level3: Level3;
+  a: string;
+  b: string;
+}
+
+interface Level1 {
+  level2: Level2;
+  a: string;
+  b: string;
+}
+
+      
+      export function Example_3(level1: Level1): void {
   const {
-    parent: { secondChild, firstChild } = { }
-  } = props;
+    level2: {
+      level3: { b, a },
+    } = {},
+  } = level1;
 }
 `,
-      output: `type Nested = {
-  parent: { firstChild: string; secondChild: string };
-};
+      output: `
+      
+      interface Level5 {
+  a: string;
+  b: string;
+}
 
-export function Example(props: Nested) {
+interface Level4 {
+  level5: Level5;
+  a: string;
+  b: string;
+}
+
+interface Level3 {
+  level4: Level4;
+  a: string;
+  b: string;
+}
+
+interface Level2 {
+  level3: Level3;
+  a: string;
+  b: string;
+}
+
+interface Level1 {
+  level2: Level2;
+  a: string;
+  b: string;
+}
+
+      
+      export function Example_3(level1: Level1): void {
   const {
-    parent: { firstChild, secondChild } = { }
-  } = props;
+    level2: {
+      level3: { a, b },
+    } = {},
+  } = level1;
 }
 `,
       errors: [{ messageId: "sort" }],

--- a/src/rules/sort-destructure-keys-by-type.test.ts
+++ b/src/rules/sort-destructure-keys-by-type.test.ts
@@ -213,23 +213,10 @@ run({
       errors: [{ messageId: "sort" }],
     },
     {
-        only: true,
+      only: true,
       description: "nested object destructuring with default values",
       code: `
-      
-      interface Level5 {
-  a: string;
-  b: string;
-}
-
-interface Level4 {
-  level5: Level5;
-  a: string;
-  b: string;
-}
-
 interface Level3 {
-  level4: Level4;
   a: string;
   b: string;
 }
@@ -246,8 +233,7 @@ interface Level1 {
   b: string;
 }
 
-      
-      export function Example_3(level1: Level1): void {
+export function Example_3(level1: Level1): void {
   const {
     level2: {
       level3: { b, a },
@@ -256,20 +242,7 @@ interface Level1 {
 }
 `,
       output: `
-      
-      interface Level5 {
-  a: string;
-  b: string;
-}
-
-interface Level4 {
-  level5: Level5;
-  a: string;
-  b: string;
-}
-
 interface Level3 {
-  level4: Level4;
   a: string;
   b: string;
 }
@@ -286,8 +259,7 @@ interface Level1 {
   b: string;
 }
 
-      
-      export function Example_3(level1: Level1): void {
+export function Example_3(level1: Level1): void {
   const {
     level2: {
       level3: { a, b },


### PR DESCRIPTION
Fixes https://github.com/nirtamir2/eslint-plugin-sort-destructure-keys-typescript/issues/3#issuecomment-2642767472
Fix deep nested value with a default value using recursion. 

```ts

export function Example_3(level1: Level1): void {
  const {
    level2: {
      level3: { b, a },
    } = {},
  } = level1;
}

```
