### PR TITLE
Return CJS build

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -4,5 +4,8 @@ export default defineBuildConfig({
   entries: ["src/index", "src/config", "src/types"],
   declaration: true,
   clean: true,
+  rollup: {
+    emitCJS: true,
+  },
   externals: ["@typescript-eslint/utils", "typescript"],
 });

--- a/package.json
+++ b/package.json
@@ -18,14 +18,17 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.mts",
+      "require": "./dist/index.cjs",
       "default": "./dist/index.mjs"
     },
     "./config": {
       "types": "./dist/config.d.mts",
+      "require": "./dist/config.cjs",
       "default": "./dist/config.mjs"
     },
     "./types": {
       "types": "./dist/types.d.mts",
+      "require": "./dist/types.cjs",
       "default": "./dist/types.mjs"
     }
   },


### PR DESCRIPTION
Some users may still use ESLint < 9 so I want to support them as of now

See https://github.com/nirtamir2/eslint-plugin-sort-destructure-keys-typescript/issues/3#issuecomment-2699790415
